### PR TITLE
Add support for namespace attributes

### DIFF
--- a/deliverance/selector.py
+++ b/deliverance/selector.py
@@ -10,7 +10,7 @@ from deliverance.exceptions import DeliveranceSyntaxError
 
 type_re = re.compile(r'^(elements?|children|tag|attributes?):')
 type_map = dict(element='elements', attribute='attributes')
-attributes_re = re.compile(r'^attributes[(]([a-zA-Z0-9_,-]+)[)]:')
+attributes_re = re.compile(r'^attributes[(]([a-zA-Z0-9_, -:]+)[)]:')
 
 class Selector(object):
     """

--- a/deliverance/tests/test_selection.txt
+++ b/deliverance/tests/test_selection.txt
@@ -2,7 +2,7 @@ First we create a theme document to test out:
 
     >>> from lxml.html import fromstring, tostring
     >>> theme = fromstring('''\
-    ... <html>
+    ... <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
     ...  <head>
     ...   <title>This is a theme title</title>
     ...   <link rel=Stylesheet type="text/css" href="style.css">
@@ -63,6 +63,8 @@ Then, lets select something:
     children:<title>This is a theme title</title>
     >>> t_select('attributes(class):#header')
     attributes:div class="title-bar"
+    >>> t_select('attributes(xml:lang):/html')
+    attributes:html xml:lang="en"
     >>> t_select('#nothing')
     >>> t_select('div')
     <div id="header" class="title-bar">


### PR DESCRIPTION
Add semicolon to allowed characters, to support matching on namespace prefixed attributes (e.g. "xml:lang").
